### PR TITLE
Reflects the permission setting of the current back-channeling.

### DIFF
--- a/src/dev/java/db/migration/V998__BackChannelingTestData.java
+++ b/src/dev/java/db/migration/V998__BackChannelingTestData.java
@@ -12,15 +12,15 @@ import static org.jooq.impl.DSL.*;
 
 public class V998__BackChannelingTestData implements JdbcMigration {
     private static final String[] ADMIN_PERMISSIONS = new String[]{
-            "create-board", "read-board", "modify-board",
-            "read-any-thread", "read-thread", "write-any-thread", "write-thread",
-            "delete-any-comment", "delete-comment"
+            "CREATE_BOARD", "READ_BOARD", "MODIFY_BOARD",
+            "READ_ANY_THREAD", "READ_THREAD", "WRITE_ANY_THREAD", "WRITE_THREAD",
+            "DELETE_ANY_COMMENT", "DELETE_COMMENT"
     };
 
     private static final String[] OTHER_PERMISSIONS = new String[]{
-            "read-board",
-            "read-thread", "write-thread",
-            "delete-comment"
+            "READ_BOARD",
+            "READ_THREAD", "WRITE_THREAD",
+            "DELETE_COMMENT"
     };
 
     private Long fetchGeneratedKey(PreparedStatement stmt) throws SQLException {

--- a/src/dev/java/db/migration/V998__BackChannelingTestData.java
+++ b/src/dev/java/db/migration/V998__BackChannelingTestData.java
@@ -13,15 +13,13 @@ import static org.jooq.impl.DSL.*;
 public class V998__BackChannelingTestData implements JdbcMigration {
     private static final String[] ADMIN_PERMISSIONS = new String[]{
             "create-board", "read-board", "modify-board",
-            "create-thread", "read-any-thread", "read-thread", "write-any-thread", "write-thread",
-            "add-watcher", "remove-watcher",
-            "read-any-comment", "delete-any-comment", "delete-comment"
+            "read-any-thread", "read-thread", "write-any-thread", "write-thread",
+            "delete-any-comment", "delete-comment"
     };
 
     private static final String[] OTHER_PERMISSIONS = new String[]{
             "read-board",
-            "create-thread", "read-thread", "write-thread",
-            "add-watcher", "remove-watcher",
+            "read-thread", "write-thread",
             "delete-comment"
     };
 


### PR DESCRIPTION
Reflects the permission setting of the current back-channeling.

# Test

Users table (is not change.)

```
mysql> select * from users;
+---------+---------+------------+-------------------+-----------------+
| user_id | account | name       | email             | write_protected |
+---------+---------+------------+-------------------+-----------------+
|       1 | admin   | Admin User | admin@example.com |               0 |
|       2 | user1   | user1      | user1@example.com |               1 |
|       3 | user2   | user2      | user2@example.com |               1 |
|       4 | user3   | user3      | user3@example.com |               1 |
+---------+---------+------------+-------------------+-----------------+
4 rows in set (0.00 sec)
```

Permission table
```
mysql> select * from permissions;
+---------------+-------------------------+-------------+-----------------+
| permission_id | name                    | description | write_protected |
+---------------+-------------------------+-------------+-----------------+
|             1 | LIST_ANY_USERS          |             |               1 |
...
|            56 | MODIFY_PERMISSION       |             |               1 |
|            57 | DELETE_PERMISSION       |             |               1 |
|            58 | READ_USER               |             |               1 |
|            59 | create-board            |             |               1 |
|            60 | read-board              |             |               1 |
|            61 | modify-board            |             |               1 |
|            62 | read-any-thread         |             |               1 |
|            63 | read-thread             |             |               1 |
|            64 | write-any-thread        |             |               1 |
|            65 | write-thread            |             |               1 |
|            66 | delete-any-comment      |             |               1 |
|            67 | delete-comment          |             |               1 |
+---------------+-------------------------+-------------+-----------------+
67 rows in set (0.00 sec)
```

Role table(is not change.)

```
mysql> select * from roles;
+---------+--------------+--------------------------------+-----------------+
| role_id | name         | description                    | write_protected |
+---------+--------------+--------------------------------+-----------------+
|       1 | BOUNCR_ADMIN | Bouncer administrations        |               1 |
|       2 | BOUNCR_USER  | Bouncr users                   |               1 |
|       3 | BC_ADMIN     | BackChanneling administrations |               0 |
|       4 | BC_USER      | BackChanneling users           |               0 |
+---------+--------------+--------------------------------+-----------------+
4 rows in set (0.00 sec)
```

Roles and Permission.
```
mysql> select permissions.name, roles.name from role_permissions left outer join permissions on permissions.permission_id = role_permissions.permission_id left outer join ro
les on roles.role_id =role_permissions.role_id order by roles.name;
+-------------------------+--------------+
| name                    | name         |
+-------------------------+--------------+
| write-any-thread        | BC_ADMIN     |
| read-board              | BC_ADMIN     |
| delete-comment          | BC_ADMIN     |
| create-board            | BC_ADMIN     |
| read-thread             | BC_ADMIN     |
| delete-any-comment      | BC_ADMIN     |
| read-any-thread         | BC_ADMIN     |
| modify-board            | BC_ADMIN     |
| write-thread            | BC_ADMIN     |
| read-board              | BC_USER      |
| delete-comment          | BC_USER      |
| read-thread             | BC_USER      |
| write-thread            | BC_USER      |
| MODIFY_ANY_GROUP        | BOUNCR_ADMIN |
| LIST_ANY_PERMISSIONS    | BOUNCR_ADMIN |
```