### PR TITLE
Initial primitive

### DIFF
--- a/src/main/java/net/unit8/bouncr/web/entity/PasswordCredential.java
+++ b/src/main/java/net/unit8/bouncr/web/entity/PasswordCredential.java
@@ -25,7 +25,7 @@ public class PasswordCredential implements Serializable {
 
     private String salt;
 
-    private Boolean initial;
+    private boolean initial;
     @EventDateTime
     private LocalDateTime createdAt;
 }

--- a/src/main/java/net/unit8/bouncr/web/service/SignInService.java
+++ b/src/main/java/net/unit8/bouncr/web/service/SignInService.java
@@ -142,7 +142,7 @@ public class SignInService {
         PasswordCredentialDao passwordCredentialDao = daoProvider.getDao(PasswordCredentialDao.class);
         PasswordCredential passwordCredential = passwordCredentialDao.selectById(user.getId());
 
-        if (passwordCredential.getInitial()) {
+        if (passwordCredential.isInitial()) {
             return INITIAL;
         }
 


### PR DESCRIPTION
Error occured in `net.unit8.bouncr.web.controller.SignUpController`.

`原因は次のものです。com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException: Column 'initial' cannot be null。`