### PR TITLE
Initial set false

### DIFF
--- a/src/main/java/net/unit8/bouncr/web/controller/SignUpController.java
+++ b/src/main/java/net/unit8/bouncr/web/controller/SignUpController.java
@@ -100,6 +100,7 @@ public class SignUpController {
                         .set(PasswordCredential::setId, user.getId())
                         .set(PasswordCredential::setPassword, PasswordUtils.pbkdf2(form.getPassword(), salt, 100))
                         .set(PasswordCredential::setSalt, salt)
+                        .set(PasswordCredential::setInitial, false)
                         .build());
             }
 


### PR DESCRIPTION
Error occured in `net.unit8.bouncr.web.controller.SignUpController`.

`原因は次のものです。com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException: Column 'initial' cannot be null。`