### PR TITLE
Fix npm script to awake redoc

### DIFF
--- a/bouncr-api-server/package.json
+++ b/bouncr-api-server/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "redoc-cli": "redoc-cli serve src/main/resources/bouncr-spec.yaml -p 8081",
-    "mock:server": "json-spec-server --port=8080 --openapi=src/main/resources/bouncr-spec.yaml --jsonspec=src/main/resources/bouncr-spec.js",
+    "redoc-cli": "redoc-cli serve src/main/resources/bouncr-spec.yaml",
+    "mock:server": "json-spec-server --port=3005 --openapi=src/main/resources/bouncr-spec.yaml --jsonspec=src/main/resources/bouncr-spec.js",
     "mock:client": "json-spec-client --baseUrl=http://localhost:3005/bouncr/api --openapi=src/main/resources/bouncr-spec.yaml"
   },
   "keywords": [

--- a/bouncr-api-server/package.json
+++ b/bouncr-api-server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "redoc-cli": "redoc-cli",
+    "redoc-cli": "redoc-cli serve src/main/resources/bouncr-spec.yaml -p 8081",
     "mock:server": "json-spec-server --port=8080 --openapi=src/main/resources/bouncr-spec.yaml --jsonspec=src/main/resources/bouncr-spec.js",
     "mock:client": "json-spec-client --baseUrl=http://localhost:3005/bouncr/api --openapi=src/main/resources/bouncr-spec.yaml"
   },


### PR DESCRIPTION
`redoc-cli serve` uses port 8080 by default, and same as `json-spec` mock server.

So I changed mock server's port.