### PR TITLE
Add missing specs to OpenAPI YAML file

### DIFF
--- a/bouncr-api-server/src/main/resources/bouncr-spec.yaml
+++ b/bouncr-api-server/src/main/resources/bouncr-spec.yaml
@@ -1441,10 +1441,13 @@ components:
       properties:
         name:
           type: string
+        url:
+          type: string
         description:
           type: string
       required:
         - name
+        - url
         - description
     RealmUpdateRequest:
       type: object

--- a/bouncr-api-server/src/main/resources/bouncr-spec.yaml
+++ b/bouncr-api-server/src/main/resources/bouncr-spec.yaml
@@ -559,6 +559,55 @@ paths:
       responses:
         204:
           description: Deleting a role is successful
+  /role/{name}/permissions:
+    parameters:
+      - $ref: '#/components/parameters/BouncrCredential'
+      - name: name
+        required: true
+        in: path
+        schema:
+          type: string
+    get:
+      summary: Find role's permissions
+      operationId: findRolePermissions
+      tags:
+        - RolePermissions
+        - Administration
+      responses:
+        200:
+          description: Finding role's permissions is successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Permissions'
+    post:
+      summary: Create role's permissions
+      operationId: createRolePermissions
+      tags:
+        - RolePermissions
+        - Administration
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RolePermissionsRequest'
+      responses:
+        201:
+          description: Creating role's permissions is successful
+    delete:
+      summary: Delete role's permissions
+      operationId: deleteRolePermissions
+      tags:
+        - RolePermissions
+        - Administration
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RolePermissionsRequest'
+      responses:
+        204:
+          description: Deleting role's permissions is successful
   /permissions:
     parameters:
     - $ref: '#/components/parameters/BouncrCredential'
@@ -1319,6 +1368,10 @@ components:
         - id
         - name
         - description
+    RolePermissionsRequest:
+      type: array
+      items:
+        type: string
     PermissionCreateRequest:
       type: object
       properties:


### PR DESCRIPTION
- There is no spec for `role/{name}/permissions` endpoint, so I added one.
- Add missing required key `url` to CreateRealmRequest.