### PR TITLE
fix hazelcast version to 3.12.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   kvs:
-    image: hazelcast/hazelcast
+    image: hazelcast/hazelcast:3.12.6
     environment:
       JAVA_OPTS: -Dhazelcast.local.publicAddress=0.0.0.0:5701
     ports:


### PR DESCRIPTION
## What
Fixed hazelcast version to 3.12.6(latest version of 3.x) in `docker-compose.yml`.

## Why
Latest image of `hazelcast/hazelcast` points 4.0, and bouncr-api-server and bouncr-proxy fail to start with `hazelcast/hazelcast:4.0` .
The best way is to update bouncr source code, but this workaround will save newbies(like me) from troubles.