### PR TITLE
test: Add OIDC IdP E2E integration tests with Playwright

### DIFF
--- a/bouncr-api-server/src/main/java/net/unit8/bouncr/api/resource/OidcApplicationsResoruce.java
+++ b/bouncr-api-server/src/main/java/net/unit8/bouncr/api/resource/OidcApplicationsResoruce.java
@@ -11,6 +11,8 @@ import net.unit8.bouncr.api.decoder.BouncrJsonDecoders;
 import net.unit8.bouncr.api.decoder.BouncrJsonDecoders.OidcApplicationCreate;
 import net.unit8.bouncr.api.repository.OidcApplicationRepository;
 import net.unit8.bouncr.component.BouncrConfiguration;
+import kotowari.restful.data.ContextKey;
+import kotowari.restful.data.RestContext;
 import net.unit8.bouncr.data.OidcApplication;
 import net.unit8.bouncr.util.KeyEncryptor;
 import net.unit8.bouncr.util.KeyUtils;
@@ -35,6 +37,8 @@ import static net.unit8.bouncr.api.decoder.BouncrJsonDecoders.toProblem;
 @AllowedMethods({"GET", "POST"})
 public class OidcApplicationsResoruce {
     static final ContextKey<OidcApplicationCreate> CREATE_REQ = ContextKey.of(OidcApplicationCreate.class);
+    @SuppressWarnings("rawtypes")
+    static final ContextKey<HashMap> RESPONSE = ContextKey.of("response", HashMap.class);
 
     @Inject
     private BouncrConfiguration config;
@@ -87,7 +91,7 @@ public class OidcApplicationsResoruce {
     }
 
     @Decision(POST)
-    public Map<String, Object> create(OidcApplicationCreate createRequest, DSLContext dsl) {
+    public boolean create(OidcApplicationCreate createRequest, RestContext context, DSLContext dsl) {
         OidcApplicationRepository repo = new OidcApplicationRepository(dsl);
 
         String clientId = RandomUtils.generateRandomString(16, config.getSecureRandom());
@@ -122,7 +126,7 @@ public class OidcApplicationsResoruce {
 
         // Return plaintext client_secret once (never stored or retrievable again)
         OidcApplication saved = repo.findByName(createRequest.name()).orElse(app);
-        Map<String, Object> response = new HashMap<>();
+        HashMap<String, Object> response = new HashMap<>();
         response.put("id", saved.id());
         response.put("name", saved.name());
         response.put("client_id", saved.clientId());
@@ -130,6 +134,13 @@ public class OidcApplicationsResoruce {
         response.put("home_url", saved.homeUrl());
         response.put("callback_url", saved.callbackUrl());
         response.put("description", saved.description());
+        context.put(RESPONSE, response);
+        return true;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Decision(HANDLE_CREATED)
+    public Map<String, Object> handleCreated(HashMap response) {
         return response;
     }
 }

--- a/bouncr-api-server/src/test/java/net/unit8/bouncr/api/resource/MockFactory.java
+++ b/bouncr-api-server/src/test/java/net/unit8/bouncr/api/resource/MockFactory.java
@@ -52,6 +52,7 @@ public class MockFactory {
             new db.migration.V25__AddRedirectUriToOidcProvider(),
             new db.migration.V26__AddJwksUriAndIssuerToOidcProvider(),
             new db.migration.V27__AddPkceEnabledToOidcProvider(),
+            new db.migration.V28__AlterOidcApplicationSecretLength(),
     };
 
     /**

--- a/bouncr-components/src/main/java/db/migration/V28__AlterOidcApplicationSecretLength.java
+++ b/bouncr-components/src/main/java/db/migration/V28__AlterOidcApplicationSecretLength.java
@@ -1,0 +1,30 @@
+package db.migration;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
+import static org.jooq.impl.DSL.*;
+
+/**
+ * Extend client_secret column to accommodate PBKDF2 hash (Base64 encoded, ~344 chars).
+ * The original VARCHAR(100) was sufficient for plaintext secrets but not for hashed values.
+ */
+public class V28__AlterOidcApplicationSecretLength extends BaseJavaMigration {
+    @Override
+    public void migrate(Context context) throws Exception {
+        Connection connection = context.getConnection();
+        DSLContext create = DSL.using(connection);
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(create.alterTable(table("oidc_applications"))
+                    .alterColumn(field("client_secret"))
+                    .set(SQLDataType.VARCHAR(512).nullable(false))
+                    .getSQL());
+        }
+    }
+}

--- a/bouncr-e2e-test/pom.xml
+++ b/bouncr-e2e-test/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.unit8.bouncr</groupId>
+        <artifactId>bouncr-parent</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <packaging>jar</packaging>
+    <artifactId>bouncr-e2e-test</artifactId>
+    <description>E2E integration tests for Bouncr OIDC IdP using Playwright</description>
+
+    <dependencies>
+        <!-- Bouncr API server (for in-process EnkanSystem startup) -->
+        <dependency>
+            <groupId>net.unit8.bouncr</groupId>
+            <artifactId>bouncr-api-server</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- H2 for in-memory database -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Playwright for HTTP + browser testing -->
+        <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>1.52.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- SLF4J for logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <JWT_SECRET>e2e-test-secret-key-32-bytes-ok</JWT_SECRET>
+                        <CLEAR_SCHEMA>true</CLEAR_SCHEMA>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/bouncr-e2e-test/src/test/java/net/unit8/bouncr/e2e/E2ETestBase.java
+++ b/bouncr-e2e-test/src/test/java/net/unit8/bouncr/e2e/E2ETestBase.java
@@ -1,0 +1,151 @@
+package net.unit8.bouncr.e2e;
+
+import com.microsoft.playwright.APIRequest;
+import com.microsoft.playwright.APIRequestContext;
+import com.microsoft.playwright.Playwright;
+import enkan.collection.OptionMap;
+import enkan.component.ApplicationComponent;
+import enkan.component.builtin.HmacEncoder;
+import enkan.component.flyway.FlywayMigration;
+import enkan.component.hikaricp.HikariCPComponent;
+import enkan.component.jackson.JacksonBeansConverter;
+import enkan.component.jetty.JettyComponent;
+import enkan.component.jooq.JooqProvider;
+import enkan.component.metrics.MetricsComponent;
+import enkan.system.EnkanSystem;
+import net.unit8.bouncr.api.hook.GrantBouncrUserRole;
+import net.unit8.bouncr.component.BouncrConfiguration;
+import net.unit8.bouncr.component.Flake;
+import net.unit8.bouncr.component.RealmCache;
+import net.unit8.bouncr.component.StoreProvider;
+import net.unit8.bouncr.component.config.HookPoint;
+import net.unit8.bouncr.component.config.PasswordPolicy;
+import net.unit8.bouncr.sign.JsonWebToken;
+import net.unit8.bouncr.sign.JwtHeader;
+import org.jooq.SQLDialect;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static enkan.component.ComponentRelationship.component;
+import static enkan.util.BeanBuilder.builder;
+
+/**
+ * Base class for E2E tests. Starts the Bouncr API server in-process
+ * with H2 in-memory database and MemoryStore (no Redis required).
+ *
+ * <p>Authentication is simulated by setting the {@code x-bouncr-credential}
+ * header with an HS256 JWT, equivalent to what bouncr-proxy sets after
+ * token lookup in production.</p>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public abstract class E2ETestBase {
+    // Must match JWT_SECRET environment variable set in pom.xml surefire config
+    protected static final String JWT_SECRET = "e2e-test-secret-key-32-bytes-ok";
+
+    protected EnkanSystem system;
+    protected String baseUrl;
+    protected Playwright playwright;
+    protected APIRequestContext api;
+
+    @BeforeAll
+    void startSystem() {
+        system = createTestSystem();
+        system.start();
+        baseUrl = "http://localhost:13005";
+
+        playwright = Playwright.create();
+        api = playwright.request().newContext(new APIRequest.NewContextOptions()
+                .setBaseURL(baseUrl));
+    }
+
+    @AfterAll
+    void stopSystem() {
+        if (api != null) api.dispose();
+        if (playwright != null) playwright.close();
+        if (system != null) system.stop();
+    }
+
+    /**
+     * Create an APIRequestContext with x-bouncr-credential header set
+     * for the given user. This simulates bouncr-proxy's authentication.
+     */
+    protected APIRequestContext authenticatedContext(long userId, String account, List<String> permissions) {
+        String credentialJwt = generateCredentialJwt(userId, account, permissions);
+        return playwright.request().newContext(new APIRequest.NewContextOptions()
+                .setBaseURL(baseUrl)
+                .setExtraHTTPHeaders(Map.of("x-bouncr-credential", credentialJwt)));
+    }
+
+    /**
+     * Generate an x-bouncr-credential JWT (HS256) for the given user.
+     */
+    private String generateCredentialJwt(long userId, String account, List<String> permissions) {
+        JsonWebToken jwt = system.getComponent("jwt");
+        Map<String, Object> claims = new LinkedHashMap<>();
+        claims.put("uid", String.valueOf(userId));
+        claims.put("sub", account);
+        claims.put("permissions", permissions);
+        claims.put("iss", "bouncr");
+        JwtHeader header = new JwtHeader("JWT", "HS256", null);
+        return jwt.sign(claims, header, JWT_SECRET.getBytes(StandardCharsets.UTF_8));
+    }
+
+    protected String basicAuth(String clientId, String clientSecret) {
+        return "Basic " + Base64.getEncoder().encodeToString(
+                (clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static EnkanSystem createTestSystem() {
+        String jdbcUrl = "jdbc:h2:mem:e2e_test;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1";
+
+        BouncrConfiguration config = builder(new BouncrConfiguration())
+                .set(BouncrConfiguration::setPasswordPolicy,
+                        builder(new PasswordPolicy())
+                                .set(PasswordPolicy::setExpires, Duration.ofDays(180))
+                                .build())
+                .set(BouncrConfiguration::setIssuerBaseUrl, "http://localhost:13005")
+                .build();
+        GrantBouncrUserRole grantBouncrUserRole = new GrantBouncrUserRole();
+        config.getHookRepo().register(HookPoint.BEFORE_CREATE_USER, grantBouncrUserRole);
+        config.getHookRepo().register(HookPoint.BEFORE_SIGN_UP, grantBouncrUserRole);
+
+        return EnkanSystem.of(
+                "hmac", new HmacEncoder(),
+                "config", config,
+                "converter", new JacksonBeansConverter(),
+                "jooq", builder(new JooqProvider())
+                        .set(JooqProvider::setDialect, SQLDialect.H2)
+                        .build(),
+                "storeprovider", new StoreProvider(),
+                "flake", new Flake(),
+                "jwt", new JsonWebToken(),
+                "realmCache", new RealmCache(),
+                "flyway", builder(new FlywayMigration())
+                        .set(FlywayMigration::setCleanBeforeMigration, true)
+                        .build(),
+                "metrics", new MetricsComponent(),
+                "datasource", new HikariCPComponent(OptionMap.of("uri", jdbcUrl)),
+                "app", new ApplicationComponent<>("net.unit8.bouncr.api.BouncrApplicationFactory"),
+                "http", builder(new JettyComponent())
+                        .set(JettyComponent::setPort, 13005)
+                        .build()
+        ).relationships(
+                component("http").using("app"),
+                component("app").using("config", "storeprovider", "realmCache", "jooq", "jwt",
+                        "converter", "metrics"),
+                component("storeprovider").using("config"),
+                component("realmCache").using("jooq", "flyway"),
+                component("jooq").using("datasource"),
+                component("flyway").using("datasource"),
+                component("jwt").using("config")
+        );
+    }
+}

--- a/bouncr-e2e-test/src/test/java/net/unit8/bouncr/e2e/OAuth2FlowTest.java
+++ b/bouncr-e2e-test/src/test/java/net/unit8/bouncr/e2e/OAuth2FlowTest.java
@@ -1,0 +1,338 @@
+package net.unit8.bouncr.e2e;
+
+import com.microsoft.playwright.APIRequestContext;
+import com.microsoft.playwright.APIResponse;
+import com.microsoft.playwright.options.RequestOptions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * E2E integration tests for the OIDC Identity Provider.
+ * Starts a full Bouncr API server and tests OAuth2/OIDC flows via HTTP.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class OAuth2FlowTest extends E2ETestBase {
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    // Admin permissions from V23 migration
+    private static final List<String> ADMIN_PERMISSIONS = List.of(
+            "oidc_application:read", "oidc_application:create",
+            "oidc_application:update", "oidc_application:delete");
+
+    // Shared state across ordered tests
+    private static String clientId;
+    private static String clientSecret;
+    private static String accessToken;
+    private static String refreshToken;
+    private static String idToken;
+    private static APIRequestContext adminApi;
+
+    @BeforeAll
+    void setupAdmin() {
+        adminApi = authenticatedContext(1L, "admin", ADMIN_PERMISSIONS);
+    }
+
+    @AfterAll
+    void cleanupAdmin() {
+        if (adminApi != null) adminApi.dispose();
+    }
+
+    // ==================== OidcApplication CRUD ====================
+
+    @Test @Order(1)
+    void createOidcApplication_returnsClientCredentials() throws Exception {
+        String payload = JSON.writeValueAsString(Map.of(
+                "name", "e2e_test_app",
+                "home_url", "http://localhost:9999",
+                "callback_url", "http://localhost:9999/callback",
+                "description", "E2E test application"));
+
+        APIResponse response = adminApi.post("/bouncr/api/oidc_applications",
+                RequestOptions.create()
+                        .setHeader("Content-Type", "application/json")
+                        .setData(payload));
+        assertThat(response.status()).isEqualTo(201);
+        byte[] body = response.body();
+        assertThat(body).as("Response body should not be empty").isNotEmpty();
+
+        Map<String, Object> app = JSON.readValue(body, Map.class);
+        clientId = (String) app.get("client_id");
+        clientSecret = (String) app.get("client_secret");
+        assertThat(clientId).isNotNull().isNotBlank();
+        assertThat(clientSecret).isNotNull().isNotBlank();
+        // client_secret is shown only once (plaintext in creation response)
+    }
+
+    // ==================== Discovery + JWKS ====================
+
+    @Test @Order(2)
+    void discovery_returnsValidConfiguration() throws Exception {
+        APIResponse response = api.get("/oauth2/openid/" + clientId + "/.well-known/openid-configuration");
+        assertThat(response.status()).isEqualTo(200);
+
+        Map<String, Object> config = JSON.readValue(response.body(), Map.class);
+        assertThat(config.get("issuer")).isEqualTo(baseUrl + "/oauth2/openid/" + clientId);
+        assertThat(config.get("authorization_endpoint")).isEqualTo(baseUrl + "/oauth2/authorize");
+        assertThat(config.get("token_endpoint")).isEqualTo(baseUrl + "/oauth2/token");
+        assertThat(config.get("userinfo_endpoint")).isEqualTo(baseUrl + "/oauth2/userinfo");
+        assertThat(config.get("revocation_endpoint")).isEqualTo(baseUrl + "/oauth2/token/revoke");
+        assertThat(config.get("introspection_endpoint")).isEqualTo(baseUrl + "/oauth2/token/introspect");
+    }
+
+    @Test @Order(3)
+    void jwks_returnsPublicKey() throws Exception {
+        APIResponse response = api.get("/oauth2/openid/" + clientId + "/certs");
+        assertThat(response.status()).isEqualTo(200);
+
+        Map<String, Object> jwks = JSON.readValue(response.body(), Map.class);
+        var keys = (List<?>) jwks.get("keys");
+        assertThat(keys).hasSize(1);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> key = (Map<String, String>) keys.get(0);
+        assertThat(key).containsKeys("kty", "use", "alg", "kid", "n", "e");
+        assertThat(key.get("kty")).isEqualTo("RSA");
+    }
+
+    @Test @Order(4)
+    void jwks_unknownClient_returns404() {
+        APIResponse response = api.get("/oauth2/openid/nonexistent/certs");
+        assertThat(response.status()).isEqualTo(404);
+    }
+
+    // ==================== Authorization Code Flow ====================
+
+    @Test @Order(10)
+    void authorizationCodeFlow_fullRoundTrip() throws Exception {
+        // PKCE code verifier + challenge
+        String codeVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        byte[] digest = MessageDigest.getInstance("SHA-256")
+                .digest(codeVerifier.getBytes(StandardCharsets.UTF_8));
+        String codeChallenge = Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+
+        // Authorization request (authenticated as admin via x-bouncr-credential)
+        String authorizeUrl = "/oauth2/authorize"
+                + "?response_type=code"
+                + "&client_id=" + clientId
+                + "&redirect_uri=" + encode("http://localhost:9999/callback")
+                + "&scope=" + encode("openid profile email")
+                + "&state=xyz123"
+                + "&nonce=nonce456"
+                + "&code_challenge=" + encode(codeChallenge)
+                + "&code_challenge_method=S256";
+
+        APIResponse authResponse = adminApi.get(authorizeUrl,
+                RequestOptions.create().setMaxRedirects(0));
+        if (authResponse.status() != 302) {
+            throw new AssertionError("Authorize failed: " + authResponse.status()
+                    + " headers=" + authResponse.headers()
+                    + " body=" + new String(authResponse.body()));
+        }
+
+        String location = authResponse.headers().get("location");
+        assertThat(location).startsWith("http://localhost:9999/callback");
+        assertThat(location).contains("code=");
+        assertThat(location).contains("state=xyz123");
+
+        // Extract authorization code
+        Map<String, String> queryParams = parseQueryParams(URI.create(location).getQuery());
+        String code = queryParams.get("code");
+        assertThat(code).isNotNull().isNotBlank();
+
+        // Exchange code for tokens
+        String tokenBody = "grant_type=authorization_code"
+                + "&code=" + encode(code)
+                + "&redirect_uri=" + encode("http://localhost:9999/callback")
+                + "&code_verifier=" + encode(codeVerifier);
+        APIResponse tokenResponse = api.post("/oauth2/token",
+                RequestOptions.create()
+                        .setHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .setHeader("Authorization", basicAuth(clientId, clientSecret))
+                        .setData(tokenBody));
+        if (tokenResponse.status() != 200) {
+            throw new AssertionError("Token exchange failed: " + tokenResponse.status()
+                    + " " + new String(tokenResponse.body()));
+        }
+
+        Map<String, Object> tokens = JSON.readValue(tokenResponse.body(), Map.class);
+        accessToken = (String) tokens.get("access_token");
+        refreshToken = (String) tokens.get("refresh_token");
+        idToken = (String) tokens.get("id_token");
+
+        assertThat(accessToken).isNotNull();
+        assertThat(refreshToken).isNotNull();
+        assertThat(idToken).isNotNull();
+        assertThat(tokens.get("token_type")).isEqualTo("Bearer");
+        assertThat(tokens.get("scope")).isEqualTo("openid profile email");
+    }
+
+    // ==================== Refresh Token ====================
+
+    @Test @Order(20)
+    void refreshToken_rotationWorks() throws Exception {
+        assertThat(refreshToken).as("refreshToken from auth code flow").isNotNull();
+
+        APIResponse response = api.post("/oauth2/token",
+                RequestOptions.create()
+                        .setHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .setHeader("Authorization", basicAuth(clientId, clientSecret))
+                        .setData(formBody("grant_type", "refresh_token", "refresh_token", refreshToken)));
+        assertThat(response.status()).isEqualTo(200);
+
+        Map<String, Object> tokens = JSON.readValue(response.body(), Map.class);
+        String newAccessToken = (String) tokens.get("access_token");
+        String newRefreshToken = (String) tokens.get("refresh_token");
+        assertThat(newAccessToken).isNotNull().isNotEqualTo(accessToken);
+        assertThat(newRefreshToken).isNotNull().isNotEqualTo(refreshToken);
+
+        // Old refresh token should be invalid (rotation)
+        APIResponse replayResponse = api.post("/oauth2/token",
+                RequestOptions.create()
+                        .setHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .setHeader("Authorization", basicAuth(clientId, clientSecret))
+                        .setData(formBody("grant_type", "refresh_token", "refresh_token", refreshToken)));
+        assertThat(replayResponse.status()).isEqualTo(400);
+
+        // Update for subsequent tests
+        accessToken = newAccessToken;
+        refreshToken = newRefreshToken;
+    }
+
+    // ==================== client_credentials ====================
+
+    @Test @Order(30)
+    void clientCredentials_issuesAccessTokenOnly() throws Exception {
+        APIResponse response = api.post("/oauth2/token",
+                RequestOptions.create()
+                        .setHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .setHeader("Authorization", basicAuth(clientId, clientSecret))
+                        .setData(formBody("grant_type", "client_credentials", "scope", "openid")));
+        assertThat(response.status()).isEqualTo(200);
+
+        Map<String, Object> tokens = JSON.readValue(response.body(), Map.class);
+        assertThat(tokens.get("access_token")).isNotNull();
+        assertThat(tokens.get("token_type")).isEqualTo("Bearer");
+        assertThat(tokens).doesNotContainKey("refresh_token");
+        assertThat(tokens).doesNotContainKey("id_token");
+    }
+
+    // ==================== UserInfo ====================
+
+    @Test @Order(40)
+    void userInfo_returnsUserClaims() throws Exception {
+        assertThat(accessToken).as("accessToken from refresh flow").isNotNull();
+
+        APIResponse response = api.get("/oauth2/userinfo",
+                RequestOptions.create()
+                        .setHeader("Authorization", "Bearer " + accessToken));
+        assertThat(response.status()).isEqualTo(200);
+
+        Map<String, Object> userInfo = JSON.readValue(response.body(), Map.class);
+        assertThat(userInfo.get("sub")).isEqualTo("admin");
+    }
+
+    // ==================== Token Introspection ====================
+
+    @Test @Order(50)
+    void introspection_validToken_returnsActive() throws Exception {
+        assertThat(accessToken).isNotNull();
+
+        APIResponse response = api.post("/oauth2/token/introspect",
+                RequestOptions.create()
+                        .setHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .setHeader("Authorization", basicAuth(clientId, clientSecret))
+                        .setData(formBody("token", accessToken)));
+        assertThat(response.status()).isEqualTo(200);
+
+        Map<String, Object> result = JSON.readValue(response.body(), Map.class);
+        assertThat(result.get("active")).isEqualTo(true);
+        assertThat(result.get("sub")).isEqualTo("admin");
+        assertThat(result.get("client_id")).isEqualTo(clientId);
+    }
+
+    @Test @Order(51)
+    void introspection_invalidToken_returnsInactive() throws Exception {
+        APIResponse response = api.post("/oauth2/token/introspect",
+                RequestOptions.create()
+                        .setHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .setHeader("Authorization", basicAuth(clientId, clientSecret))
+                        .setData(formBody("token", "invalid.jwt.token")));
+        assertThat(response.status()).isEqualTo(200);
+
+        Map<String, Object> result = JSON.readValue(response.body(), Map.class);
+        assertThat(result.get("active")).isEqualTo(false);
+    }
+
+    // ==================== Token Revocation ====================
+
+    @Test @Order(60)
+    void revocation_invalidatesRefreshToken() throws Exception {
+        assertThat(refreshToken).as("refreshToken from refresh flow").isNotNull();
+
+        APIResponse revokeResponse = api.post("/oauth2/token/revoke",
+                RequestOptions.create()
+                        .setHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .setHeader("Authorization", basicAuth(clientId, clientSecret))
+                        .setData(formBody("token", refreshToken)));
+        assertThat(revokeResponse.status()).isEqualTo(200);
+
+        // Revoked refresh token should be invalid
+        APIResponse refreshResponse = api.post("/oauth2/token",
+                RequestOptions.create()
+                        .setHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .setHeader("Authorization", basicAuth(clientId, clientSecret))
+                        .setData(formBody("grant_type", "refresh_token", "refresh_token", refreshToken)));
+        assertThat(refreshResponse.status()).isEqualTo(400);
+
+        Map<String, Object> error = JSON.readValue(refreshResponse.body(), Map.class);
+        assertThat(error.get("error")).isEqualTo("invalid_grant");
+    }
+
+    // ==================== Helpers ====================
+
+    private static String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Build application/x-www-form-urlencoded body from key-value pairs.
+     */
+    private static String formBody(String... pairs) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < pairs.length; i += 2) {
+            if (sb.length() > 0) sb.append("&");
+            sb.append(encode(pairs[i])).append("=").append(encode(pairs[i + 1]));
+        }
+        return sb.toString();
+    }
+
+    private static Map<String, String> parseQueryParams(String query) {
+        Map<String, String> params = new HashMap<>();
+        if (query == null) return params;
+        for (String pair : query.split("&")) {
+            String[] kv = pair.split("=", 2);
+            if (kv.length == 2) {
+                params.put(URLDecoder.decode(kv[0], StandardCharsets.UTF_8),
+                        URLDecoder.decode(kv[1], StandardCharsets.UTF_8));
+            }
+        }
+        return params;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <module>bouncr-api-server</module>
         <module>bouncr-hook-email</module>
         <module>bouncr-hook-license</module>
+        <module>bouncr-e2e-test</module>
     </modules>
 
     <distributionManagement>


### PR DESCRIPTION
## Summary

New `bouncr-e2e-test` Maven module with 11 E2E integration tests for the OIDC IdP, using Playwright's `APIRequestContext` for HTTP testing.

### Test Architecture

- In-process EnkanSystem startup (H2 + MemoryStore, no Docker)
- Authentication via `x-bouncr-credential` HS256 JWT header (simulates bouncr-proxy)
- Playwright for HTTP requests (no browser needed for API tests, browser ready for future consent UI tests)

### 11 Test Scenarios

| # | Test | Validates |
|---|---|---|
| 1 | Create OidcApplication | Admin API + PBKDF2 hashed secret + one-time plaintext return |
| 2 | Discovery | All endpoint URLs correct |
| 3 | JWKS | RSA public key with JWK format |
| 4 | JWKS unknown client | 404 |
| 5 | Auth Code Flow | Full roundtrip: authorize → code → token exchange with PKCE |
| 6 | Refresh Token | Rotation: new tokens, old token rejected |
| 7 | client_credentials | access_token only, no refresh/id_token |
| 8 | UserInfo | Bearer JWT → user claims |
| 9 | Introspection (valid) | active=true with claims |
| 10 | Introspection (invalid) | active=false |
| 11 | Revocation | Refresh token invalidated |

### Production Bugs Found

1. **client_secret VARCHAR(100)** — too short for PBKDF2 hash (344 chars). Fixed with V28 migration → VARCHAR(512)
2. **OidcApplicationsResoruce.create()** — returned Map from `@Decision(POST)` instead of using `HANDLE_CREATED`, causing empty response body. Fixed with proper ContextKey + HANDLE_CREATED pattern.

### Running

```bash
# E2E tests only
mvn test -pl bouncr-e2e-test -am

# Unit tests only (E2E not included since it's a separate module)
mvn test -pl bouncr-api-server -am
```

## Test plan

- [x] All 11 E2E tests pass
- [x] Existing unit tests still pass (`mvn test -pl bouncr-api-server -am`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)