### PR TITLE
Bump hono from 4.12.14 to 4.12.25 in /bouncr-ui

### DIFF
--- a/bouncr-ui/package-lock.json
+++ b/bouncr-ui/package-lock.json
@@ -7005,9 +7005,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Applies the hono bump on top of `develop` (indirect dep of `@modelcontextprotocol/sdk`, range `^4.11.4`).

Supersedes #156: the Dependabot PR was branched from `master` (lags `develop`) and conflicts. `develop` already had hono 4.12.14 via #141; `npm update hono` pulls the latest within range (4.12.25), which covers #156's 4.12.23 target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)