### PR TITLE
Bump dompurify from 3.4.0 to 3.4.10 in /bouncr-api-server

### DIFF
--- a/bouncr-api-server/package-lock.json
+++ b/bouncr-api-server/package-lock.json
@@ -1500,9 +1500,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {


### PR DESCRIPTION
Applies the dompurify bump on top of `develop` (indirect dep of `redoc`, range `^3.2.4`).

Supersedes #142: the Dependabot PR was branched from `master` (lags `develop`) and conflicts. `develop` already had dompurify 3.4.0 via #141; `npm update dompurify` pulls the latest within range (3.4.10), covering #142's 3.4.1 target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)